### PR TITLE
Fix issue #18 and cleanup correctly on container shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ First of all you need a key pair for the server. Use the following command to ge
 docker run --rm -i masipcat/wireguard-go wg genkey > privatekey
 
 # Generate publickey from privatekey
-docker run --rm -i masipcat/wireguard-go wg genkey < privatekey > publickey
+docker run --rm -i masipcat/wireguard-go wg pubkey < privatekey > publickey
 ```
 
 ## Run server

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,5 @@ trap finish SIGTERM SIGINT SIGQUIT
 wg-quick up /etc/wireguard/wg0.conf
 
 # Inifinite sleep
-while true; do
-    sleep 86400
-    wait $!
-done
+sleep infinity &
+wait $!


### PR DESCRIPTION
Fixed entrypoint.sh to properly clean-up (run this `finish()` function) on container shutdown. This ensures the wg0 interface and iptables rules dont linger around (the presence of the lingering wg0 interface actually made starting the container again after a shutdown fail because the interface was found to already exist).

Also, fixed a small typo in the readme for generating public key from private key. (As reported in issue #18)