### PR TITLE
add lightweight http healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,11 +22,15 @@ RUN git clone https://git.zx2c4.com/wireguard-tools && \
     make && \
     make install
 
+COPY healthcheck.go /go/src/healthcheck.go
+RUN go build -o /go/bin/healthcheck /go/src/healthcheck.go
+
 FROM alpine:${ALPINE_VERSION}
 
 RUN apk add --no-cache --update bash libmnl iptables openresolv iproute2
 
 COPY --from=builder /usr/bin/wireguard-go /usr/bin/wg* /usr/bin/
+COPY --from=builder /go/bin/healthcheck /usr/bin/healthcheck
 COPY entrypoint.sh /entrypoint.sh
 
 CMD ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -134,6 +134,14 @@ spec:
           - containerPort: 51820
             protocol: UDP
             name: wireguard
+          - containerPort: 8080
+            protocol: TCP
+            name: healthcheck
+          livenessProbe: &probe
+            httpGet:
+              path: /
+              port: healthcheck
+          readinessProbe: *probe
           env:
           - name: LOG_LEVEL
             value: info

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,9 @@ trap finish SIGTERM SIGINT SIGQUIT
 
 wg-quick up /etc/wireguard/wg0.conf
 
-# Inifinite sleep
+# Infinite sleep
 sleep infinity &
+
+# Health check
+/usr/bin/healthcheck &
 wait $!

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+)
+
+func isLinkUp(interfaceName string) bool {
+	content, err := ioutil.ReadFile("/sys/class/net/" + interfaceName + "/carrier")
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(content)) == "1"
+}
+
+func healthCheckHandler(w http.ResponseWriter, r *http.Request) {
+	if isLinkUp("wg0") {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, "status: OK\n")
+	} else {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		fmt.Fprintf(w, "status: KO\n")
+	}
+}
+
+func main() {
+	http.HandleFunc("/", healthCheckHandler)
+	if err := http.ListenAndServe(":8080", nil); err != nil {
+		fmt.Printf("Failed to start server: %v\n", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
Adds a basic http health check endpoint
Leverages existing build env, no added dependencies
Only ~3.5 MB increased image size
Enables use of load balancer