### PR TITLE
Health server improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN git clone https://git.zx2c4.com/wireguard-tools && \
     make install
 
 COPY healthcheck.go /go/src/healthcheck.go
-RUN go build -o /go/bin/healthcheck /go/src/healthcheck.go
+RUN go build -ldflags="-s -w" -o /go/bin/healthcheck /go/src/healthcheck.go
 
 FROM alpine:${ALPINE_VERSION}
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ spec:
           - name: LOG_LEVEL
             value: info
           - name: ENABLE_HEALTHCHECK
-            value: true
+            value: "true"
           securityContext:
             capabilities:
               add:

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -1,35 +1,60 @@
 package main
 
 import (
-	"fmt"
-	"io/ioutil"
-	"net/http"
+	"bufio"
+	"io"
+	"net"
 	"os"
 	"strings"
 )
 
 func isLinkUp(interfaceName string) bool {
-	content, err := ioutil.ReadFile("/sys/class/net/" + interfaceName + "/carrier")
+	content, err := os.ReadFile("/sys/class/net/" + interfaceName + "/carrier")
 	if err != nil {
 		return false
 	}
 	return strings.TrimSpace(string(content)) == "1"
 }
 
-func healthCheckHandler(w http.ResponseWriter, r *http.Request) {
+func handleConnection(conn net.Conn) {
+	defer conn.Close() // Ensure each connection is closed after handling
+
+	// Read the request (we don't need to parse it for this simple healthcheck)
+	bufio.NewReader(conn).ReadString('\n')
+
+	status := "KO"
+	statusCode := "503 Service Unavailable"
 	if isLinkUp("wg0") {
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, "status: OK\n")
-	} else {
-		w.WriteHeader(http.StatusServiceUnavailable)
-		fmt.Fprintf(w, "status: KO\n")
+		status = "OK"
+		statusCode = "200 OK"
 	}
+
+	// Write HTTP response
+	io.WriteString(conn, "HTTP/1.1 "+statusCode+"\r\n")
+	io.WriteString(conn, "Content-Type: text/plain\r\n")
+	io.WriteString(conn, "\r\n")
+	io.WriteString(conn, "status: "+status+"\n")
 }
 
 func main() {
-	http.HandleFunc("/", healthCheckHandler)
-	if err := http.ListenAndServe(":8080", nil); err != nil {
-		fmt.Printf("Failed to start server: %v\n", err)
+	port := "8080" // Default port
+	if envPort := os.Getenv("HEALTHCHECK_PORT"); envPort != "" {
+		port = envPort
+	}
+
+	listener, err := net.Listen("tcp", ":"+port)
+	if err != nil {
+		os.Stderr.WriteString("Failed to start server: " + err.Error() + "\n")
 		os.Exit(1)
+	}
+	defer listener.Close()
+
+	// Accept new connections and handle each in a separate goroutine
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			continue // If accept fails, continue to next connection
+		}
+		go handleConnection(conn)
 	}
 }


### PR DESCRIPTION
Good call on making this feature opt-in.  I have some additional proposed improvements.

- Fixes yaml syntax in k8s example manifest
- Adds optional `HEALTHCHECK_PORT` env var
- Strip health server binary
- Minimize health server, imports
- Reduces image size by ~2.87MB
- Reduces memory footprint